### PR TITLE
Made ShrubParticle default state be randomized from preset foliage.

### DIFF
--- a/src/main/java/pigcart/particlerain/particle/ShrubParticle.java
+++ b/src/main/java/pigcart/particlerain/particle/ShrubParticle.java
@@ -48,7 +48,11 @@ public class ShrubParticle extends WeatherParticle {
                 this.setColor(color.getRed() / 255F, color.getGreen() / 255F, color.getBlue() / 255F);
             }
         } else {
-            blockState = Blocks.DEAD_BUSH.defaultBlockState();
+            blockState = switch (level.random.nextInt(3)) {
+                case 0 -> Blocks.SHORT_DRY_GRASS.defaultBlockState();
+                case 1 -> Blocks.TALL_DRY_GRASS.defaultBlockState();
+                default -> Blocks.DEAD_BUSH.defaultBlockState();
+            };
         }
         this.setSprite(Minecraft.getInstance().getBlockRenderer().getBlockModel(blockState).particleIcon());
     }


### PR DESCRIPTION
Made the default block state of the Shrub particle be randomized between the 2 dry grass variants and the shrub. Since the dry grass is more common than shrubs. But the Particle is more likely to pick the hardcoded variant then select an in world block. Which results in shrubs being a lot more common.