### PR TITLE
Add custom heightmap cache for configurable ignored blocks

### DIFF
--- a/src/main/java/pigcart/particlerain/ParticleRain.java
+++ b/src/main/java/pigcart/particlerain/ParticleRain.java
@@ -26,6 +26,7 @@ import pigcart.particlerain.particle.render.BlendedParticleRenderType;
 import java.util.List;
 import java.util.Set;
 
+import static pigcart.particlerain.ParticleSpawner.getCachedHeight;
 import static pigcart.particlerain.config.ConfigManager.config;
 
 public class ParticleRain {
@@ -115,6 +116,8 @@ public class ParticleRain {
     }
 
     public static void doAdditionalWeatherSounds(ClientLevel level, BlockPos cameraPos, BlockPos rainPos, CallbackInfo ci) {
+        int newy = getCachedHeight(level, rainPos.getX(), rainPos.getZ());
+        rainPos = new BlockPos(rainPos.getX(), newy, rainPos.getZ());
         if (config.compat.doSpawnHeightLimit) {
             int cloudHeight = config.compat.spawnHeightLimit == 0 ? VersionUtil.getCloudHeight(level, rainPos) : config.compat.spawnHeightLimit;
             if (rainPos.getY() > cloudHeight) {
@@ -123,7 +126,7 @@ public class ParticleRain {
             }
         }
         boolean above = rainPos.getY() > cameraPos.getY() + 1
-                && level.getHeightmapPos(Heightmap.Types.MOTION_BLOCKING, cameraPos).getY() > Mth.floor((float)cameraPos.getY());
+                && getCachedHeight(level, cameraPos.getX(), cameraPos.getZ()) > Mth.floor((float)cameraPos.getY());
         Holder<Biome> biome = level.getBiome(rainPos);
         Biome.Precipitation precipitation = VersionUtil.getPrecipitationAt(level, biome, rainPos);
         if (precipitation == Biome.Precipitation.SNOW && config.sound.snowVolume > 0) {

--- a/src/main/java/pigcart/particlerain/ParticleSpawner.java
+++ b/src/main/java/pigcart/particlerain/ParticleSpawner.java
@@ -5,6 +5,7 @@ import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.Holder;
+import net.minecraft.tags.BlockTags;
 import net.minecraft.util.Mth;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.level.biome.Biome;
@@ -14,7 +15,10 @@ import net.minecraft.world.level.levelgen.Heightmap;
 import net.minecraft.world.level.material.FluidState;
 import net.minecraft.world.phys.Vec3;
 import org.joml.Quaternionf;
+import net.minecraft.world.level.block.Blocks;
 import org.joml.Vector3f;
+import it.unimi.dsi.fastutil.longs.Long2IntMap;
+import it.unimi.dsi.fastutil.longs.Long2IntOpenHashMap;
 import pigcart.particlerain.config.ParticleData;
 import pigcart.particlerain.particle.CustomParticle;
 import pigcart.particlerain.particle.StreakParticle;
@@ -43,13 +47,69 @@ public final class ParticleSpawner {
         afterWeatherTicksLeft = isRaining ? 0 : RandomSource.create().nextInt(6000); // 'after weather' period lasts up to 5 minutes
     }
 
+    public static boolean isIgnoredByConfig(BlockState state){
+    return  config.compat.rainHeightIgnoreBlocks != null
+            && !config.compat.rainHeightIgnoreBlocks.getEntries().isEmpty()
+            && config.compat.rainHeightIgnoreBlocks.contains(state.getBlockHolder());
+    }
+
+    public static int getCustomRainHeight(ClientLevel level, int x, int z) {
+        int y = level.getHeight(Heightmap.Types.MOTION_BLOCKING, x, z);
+        if(y == 0) y=255; //Some servers (like wynncraft) send a map of 0 for MOTION_BLOCKING;
+        BlockPos.MutableBlockPos mutablePos = new BlockPos.MutableBlockPos(x, y, z);
+
+        //? if >=1.21.9 {
+        /*int minY = level.getMinY();
+        *///?} else {
+        int minY = -64;
+        //?}
+
+        while (y > minY) {
+            BlockState state = level.getBlockState(mutablePos);
+
+            boolean noCollision = state.getCollisionShape(level, pos).isEmpty();
+            boolean isIgnoredByConfig = isIgnoredByConfig(state);
+
+            if (noCollision || isIgnoredByConfig) {
+                y--;
+                mutablePos.setY(y);
+            } else {
+                break;
+            }
+        }
+        return y;
+    }
+
+    private static final Long2IntMap heightCache = new Long2IntOpenHashMap();
+    private static int lastTick = 0;
+
+    public static int getCachedHeight(ClientLevel level, int x, int z) {
+        if (config.compat.rainHeightIgnoreBlocks == null || config.compat.rainHeightIgnoreBlocks.getEntries().isEmpty()) {
+            return level.getHeight(Heightmap.Types.MOTION_BLOCKING, x, z);
+        }
+
+        if (level.getGameTime() != lastTick) {
+            if (level.getGameTime() % 80 == 0) heightCache.clear();
+            lastTick = (int) level.getGameTime();
+        }
+        long key = ((long) x << 32) | (z & 0xFFFFFFFFL);
+
+        if (heightCache.containsKey(key)) {
+            return heightCache.get(key);
+        }
+
+        int customY = getCustomRainHeight(level, x, z);
+        heightCache.put(key, customY);
+        return customY;
+    }
+
     public static void tickBlockFX(BlockPos.MutableBlockPos sourcePos, BlockState state, RandomSource random) {
         ClientLevel level = Minecraft.getInstance().level;
         if (spawnAttemptsUntilBlockFXIdle <= 0 && level.getRandom().nextFloat() < 0.9F) {
             return;
         }
         spawnAttemptsUntilBlockFXIdle--;
-        if (!state.getCollisionShape(level, sourcePos).isEmpty()) return;
+        if ( !state.getCollisionShape(level, sourcePos).isEmpty() && !isIgnoredByConfig(state) ) return;
         for (ParticleData opts : ParticleLoader.particles.values()) {
             if (!opts.enabled || !opts.weather.isCurrent(level)) continue;
             final Holder<Biome> biome = level.getBiome(sourcePos);
@@ -64,14 +124,14 @@ public final class ParticleSpawner {
             pos.set(sourcePos.getX() + opposite.getStepX(), sourcePos.getY() + opposite.getStepY(), sourcePos.getZ() + opposite.getStepZ());
             final BlockState blockState = level.getBlockState(pos);
             final FluidState fluidState = blockState.getFluidState();
-            if (blockState.getCollisionShape(level, pos).isEmpty() && fluidState.isEmpty()) continue;
+            if ((blockState.getCollisionShape(level, pos).isEmpty() && fluidState.isEmpty()) || isIgnoredByConfig(state) ) continue;
             if ((opts.spawnPos == ParticleData.SpawnPos.BLOCK_BOTTOM || opts.spawnPos == ParticleData.SpawnPos.BLOCK_SIDES || opts.spawnPos == ParticleData.SpawnPos.BLOCK_TOP)
                     && opts.precipitation.contains(VersionUtil.getPrecipitationAt(level, biome, sourcePos))
                     && opts.density > random.nextFloat()
                     && opts.biomeList.contains(biome)
                     && opts.blockList.contains(level.getBlockState(pos).getBlockHolder())
             ) {
-                if (opts.needsSkyAccess && sourcePos.getY() < level.getHeight(Heightmap.Types.MOTION_BLOCKING, sourcePos.getX(), sourcePos.getZ())) continue;
+                if (opts.needsSkyAccess && sourcePos.getY() < getCachedHeight(level, sourcePos.getX(), sourcePos.getZ())    ) continue;
                 // get position on block face
                 float p1 = random.nextFloat();
                 float p2 = random.nextFloat();
@@ -152,7 +212,7 @@ public final class ParticleSpawner {
                     pos.setY(cloudHeight);
                 }
             }
-            int heightmapY = level.getHeight(Heightmap.Types.MOTION_BLOCKING, pos.getX(), pos.getZ());
+            int heightmapY = getCachedHeight(level, pos.getX(), pos.getZ());
             heightmapPos.set(x, heightmapY - 1, z);
             if (heightmapY > pos.getY()) continue;
             Holder<Biome> biome = level.getBiome(pos);
@@ -188,7 +248,7 @@ public final class ParticleSpawner {
         for (int i = 0; i < density; i++) {
             double x = RANDOM.triangle(cameraPos.x, config.perf.surfaceRange);
             double z = RANDOM.triangle(cameraPos.z, config.perf.surfaceRange);
-            int y = level.getHeight(Heightmap.Types.MOTION_BLOCKING, (int) x, (int) z);
+            int y = getCachedHeight(level, (int) x, (int) z);
             pos.set(x, y - 1, z);
             BlockState blockState = level.getBlockState(pos);
             Holder<Biome> biome = level.getBiome(pos);

--- a/src/main/java/pigcart/particlerain/config/ConfigData.java
+++ b/src/main/java/pigcart/particlerain/config/ConfigData.java
@@ -4,6 +4,8 @@ import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import pigcart.particlerain.VersionUtil;
 import pigcart.particlerain.particle.render.BlendedParticleRenderType;
 import pigcart.particlerain.config.gui.Annotations.*;
+import java.util.ArrayList;
+import java.util.List;
 //? if >=1.21.9 {
 /*import net.minecraft.client.renderer.state./^?>=26.1{^//^level.^//^?}^/QuadParticleRenderState;
 import net.minecraft.client.particle.SingleQuadParticle;
@@ -15,6 +17,12 @@ import static pigcart.particlerain.config.ConfigResponders.*;
 
 public class ConfigData {
     @NoGUI public byte configVersion = 5;
+
+    public void updateTransientVariables() {
+        if (compat != null && compat.rainHeightIgnoreBlocks != null) {
+            compat.rainHeightIgnoreBlocks.populateInternalLists();
+        }
+    }
 
     public PerformanceOptions perf = new PerformanceOptions();
     public static class PerformanceOptions {
@@ -57,6 +65,9 @@ public class ConfigData {
         public boolean crossBiomeBorder = false;
         public boolean useHeightmapTemp = true;
         public boolean doSpawnHeightLimit = false;
+        public Whitelist.BlockList rainHeightIgnoreBlocks = new Whitelist.BlockList(true, new ArrayList<>(
+                List.of("#minecraft:fences", "#minecraft:all_signs", "#minecraft:leaves")
+        ));
         @Format(ZeroIsAutomatic.class)
         public int spawnHeightLimit = 0;
     }

--- a/src/main/java/pigcart/particlerain/config/ConfigManager.java
+++ b/src/main/java/pigcart/particlerain/config/ConfigManager.java
@@ -44,6 +44,7 @@ public class ConfigManager {
             config = getDefaultConfig();
             save();
         }
+        config.updateTransientVariables();
     }
 
     public static void save() {
@@ -53,6 +54,7 @@ public class ConfigManager {
             ParticleRain.LOGGER.error("Couldn't create directory 'config/particlerain/'", e);
         }
         try (FileWriter writer = new FileWriter(CONFIG_PATH)) {
+            config.updateTransientVariables();
             GSON.toJson(config, writer);
         } catch (IOException e) {
             ParticleRain.LOGGER.error("Couldn't save config", e);

--- a/src/main/java/pigcart/particlerain/config/ParticleData.java
+++ b/src/main/java/pigcart/particlerain/config/ParticleData.java
@@ -94,17 +94,17 @@ public class ParticleData {
     public enum Weather {
         DURING_WEATHER {
             public Boolean isCurrent(ClientLevel level) {
-                return level.isRaining();
+                return level.getRainLevel(1) > 0;
             }
         },
         ONLY_DURING_NORMAL_WEATHER {
             public Boolean isCurrent(ClientLevel level) {
-                return level.isRaining() && !level.isThundering();
+                return level.getRainLevel(1) > 0 && level.getThunderLevel(1) == 0;
             }
         },
         ONLY_DURING_STORMY_WEATHER {
             public Boolean isCurrent(ClientLevel level) {
-                return level.isThundering();
+                return level.getThunderLevel(1) == 0;
             }
         },
         AFTER_WEATHER {
@@ -114,7 +114,7 @@ public class ParticleData {
         },
         CLEAR {
             public Boolean isCurrent(ClientLevel level) {
-                return !level.isRaining();
+                return !(level.getRainLevel(1) > 0);
             }
         },
         ALWAYS;

--- a/src/main/java/pigcart/particlerain/mixin/render/WeatherEffectRendererMixin.java
+++ b/src/main/java/pigcart/particlerain/mixin/render/WeatherEffectRendererMixin.java
@@ -15,12 +15,15 @@ import net.minecraft.sounds.SoundEvent;
 import net.minecraft.sounds.SoundSource;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.biome.Biome;
+import net.minecraft.world.level.levelgen.Heightmap;
 import net.minecraft.world.phys.Vec3;
 import org.objectweb.asm.Opcodes;
+import pigcart.particlerain.ParticleSpawner;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import pigcart.particlerain.ParticleRain;
 //? if >=1.21.9 {
@@ -44,6 +47,18 @@ public abstract class WeatherEffectRendererMixin {
     @Inject(method = "tickRainParticles", at = @At(value = "FIELD", opcode = Opcodes.PUTFIELD, shift = At.Shift.AFTER, ordinal = 1, target = "Lnet/minecraft/client/renderer/WeatherEffectRenderer;rainSoundTime:I"), cancellable = true)
     public void hookWeatherSounds(ClientLevel level, Camera camera, int ticks, ParticleStatus particleStatus,/^?>=1.21.11{^//^int weatherRadius,^//^?}^/ CallbackInfo ci, @Local(ordinal = 0) BlockPos blockPos, @Local(ordinal = 1) BlockPos blockPos2) {
         ParticleRain.doAdditionalWeatherSounds(level, blockPos, blockPos2, ci);
+    }
+
+    @WrapOperation(
+            method = "tickRainParticles",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/client/multiplayer/ClientLevel;getHeightmapPos(Lnet/minecraft/world/level/levelgen/Heightmap$Types;Lnet/minecraft/core/BlockPos;)Lnet/minecraft/core/BlockPos;"
+            )
+    )
+    public BlockPos alterHeightmapPos(ClientLevel instance, Heightmap.Types types, BlockPos blockPos, Operation<BlockPos> original) {
+        int newY = ParticleSpawner.getCachedHeight(instance, blockPos.getX(), blockPos.getZ());
+        return new BlockPos(blockPos.getX(), newY, blockPos.getZ());
     }
 
     // make rain sound use the mods rain volume slider
@@ -99,6 +114,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import pigcart.particlerain.ParticleRain;
+import pigcart.particlerain.ParticleSpawner;
 import pigcart.particlerain.config.ConfigManager;
 
 import static pigcart.particlerain.config.ConfigManager.config;
@@ -111,6 +127,19 @@ public class WeatherEffectRendererMixin {
     public Holder<Biome> getBiomeValue(LevelReader instance, BlockPos pos, Operation<Holder<Biome>> original) {
         // mixin somehow can't resolve target getPrecipitationAt so lets just replace the gotten biome with a rainy one instead
         return Minecraft.getInstance().level.registryAccess().registryOrThrow(Registries.BIOME).getHolderOrThrow(Biomes.PLAINS);
+    }
+
+    @WrapOperation(
+            method = "tickRain",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/world/level/LevelReader;getHeightmapPos(Lnet/minecraft/world/level/levelgen/Heightmap$Types;Lnet/minecraft/core/BlockPos;)Lnet/minecraft/core/BlockPos;"
+            )
+    )
+    public BlockPos alterHeightmapPos(net.minecraft.world.level.LevelReader instance, net.minecraft.world.level.levelgen.Heightmap.Types types, BlockPos blockPos, Operation<BlockPos> original) {
+        ClientLevel level = (ClientLevel) instance;
+        int newY = ParticleSpawner.getCachedHeight(level, blockPos.getX(), blockPos.getZ());
+        return new BlockPos(blockPos.getX(), newY, blockPos.getZ());
     }
 
     // insert additional sounds without replacing vanilla code block where rain sounds are played

--- a/src/main/java/pigcart/particlerain/particle/CustomParticle.java
+++ b/src/main/java/pigcart/particlerain/particle/CustomParticle.java
@@ -3,12 +3,14 @@ package pigcart.particlerain.particle;
 import com.mojang.math.Axis;
 import net.minecraft.client.Camera;
 import net.minecraft.client.Minecraft;
+import net.minecraft.tags.BlockTags;
 import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.client.particle.Particle;
 import net.minecraft.client.particle.ParticleProvider;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.particles.SimpleParticleType;
 import net.minecraft.util.Mth;
+import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.HitResult;
 import net.minecraft.world.phys.Vec3;
@@ -126,7 +128,18 @@ public class CustomParticle extends WeatherParticle {
     public void onPositionUpdate() {
         if (!config.compat.crossBiomeBorder && Mth.abs(level.getBiome(pos).value().getBaseTemperature() - baseTemp) > 0.4) {
             this.remove();
+            return;
         }
+
+        BlockState state = level.getBlockState(pos);
+        boolean isIgnoredByConfig = config.compat.rainHeightIgnoreBlocks != null
+                && !config.compat.rainHeightIgnoreBlocks.getEntries().isEmpty()
+                && config.compat.rainHeightIgnoreBlocks.contains(state.getBlockHolder());
+
+        if(isIgnoredByConfig && level.getFluidState(pos).isEmpty()) {
+            return;
+        }
+
         if (level.getBlockState(pos).isCollisionShapeFullBlock(level, pos) || !level.getFluidState(pos).isEmpty()) {
             this.remove();
         }
@@ -148,6 +161,16 @@ public class CustomParticle extends WeatherParticle {
     }
 
     public void onCollision(BlockHitResult hitResult) {
+
+        BlockState state = level.getBlockState(hitResult.getBlockPos());
+        boolean isIgnoredByConfig = config.compat.rainHeightIgnoreBlocks != null
+                && !config.compat.rainHeightIgnoreBlocks.getEntries().isEmpty()
+                && config.compat.rainHeightIgnoreBlocks.contains(state.getBlockHolder());
+
+        if(isIgnoredByConfig) {
+            return;
+        }
+
         if (opts.bounciness != 0) {
             final Vector3f normal = hitResult.getDirection().step();
             final float bounciness = opts.bounciness * speed;
@@ -166,7 +189,7 @@ public class CustomParticle extends WeatherParticle {
         if (!opts.rotationType.equals(ParticleData.RotationType.RELATIVE_VELOCITY)) {
             quadSize -= speed;
         }
-        if (oCollisionAnimProgress <= 0) remove();
+        if (oCollisionAnimProgress <= 0) { remove(); }
     }
 
     public float getDistanceSize() {

--- a/src/main/java/pigcart/particlerain/particle/WeatherParticle.java
+++ b/src/main/java/pigcart/particlerain/particle/WeatherParticle.java
@@ -14,6 +14,7 @@ import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.core.BlockPos;
 import net.minecraft.util.Mth;
+import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.Vec3;
 import org.joml.Quaternionf;
 import org.joml.Vector3f;
@@ -82,6 +83,14 @@ public abstract class WeatherParticle extends /*? if >=1.21.9 {*/ /*SingleQuadPa
     public void onPositionUpdate() {
         if (!config.compat.crossBiomeBorder && Mth.abs(level.getBiome(pos).value().getBaseTemperature() - baseTemp) > 0.4) {
             doCollisionAnim = true;
+        }
+        BlockState state = level.getBlockState(pos);
+        boolean isIgnoredByConfig = config.compat.rainHeightIgnoreBlocks != null
+                && !config.compat.rainHeightIgnoreBlocks.getEntries().isEmpty()
+                && config.compat.rainHeightIgnoreBlocks.contains(state.getBlockHolder());
+
+        if(isIgnoredByConfig && level.getFluidState(pos).isEmpty()) {
+            return;
         }
         if (level.getBlockState(pos).isCollisionShapeFullBlock(level, pos) || !level.getFluidState(pos).isEmpty()) {
             this.remove();

--- a/src/main/resources/assets/particlerain/lang/en_us.json
+++ b/src/main/resources/assets/particlerain/lang/en_us.json
@@ -73,6 +73,8 @@
   "particlerain.doSpawnHeightLimit.description": "Prevents weather particles from spawning above the cloud height.",
   "particlerain.spawnHeightLimit": "Spawn height limit",
   "particlerain.spawnHeightLimit.description": "The height at which particles are considered to be spawning above clouds. When set to a value of zero the mod will use the cloud height from the current world.",
+  "particlerain.rainHeightIgnoreBlocks": "Rain height ignore blocks",
+  "particlerain.rainHeightIgnoreBlocks.description": "Blocks or tags that should be ignored when finding the rain height (ex: fences, signs).",
 
   "particlerain.particles": "Edit Particles",
   "particlerain.presetParticleId": "Preset particle",


### PR DESCRIPTION
Changes:

-Modified code to support blocks to be ignored (like air) in spawning, soundplay, colliding and ceiling checks using a custom heightmap.

-The Custom height map uses caches that refreshes every 80 ticks (can be changed in the code)

-Added custom config to change which blocks are ignored

-Change some isRaining() checks to getRainLevel(1) > 0 to make mod compatible with Weather Changer mod.

This option work in all supported versions


Basically, I really like this mod to use in wynncraft, a server that does not rain by default and has a barrier block at height limit. But, every time the server updates the minecraft version, I needed to download the mod source again and edit some code to allow it to work. 

So I'm making these changes to allow the user to select which block is to be ignored (By default I set only  "#minecraft:fences", "#minecraft:all_signs", "#minecraft:leaves") using a custom heightmap. Also, some servers send just a bunch of 0s in Heightmap.Type.Motion_Block, so this custom Heightmap also fixes it.
If there are no blocks to be ignored, the mod just uses  Heightmap.Type.Motion_Block as now.

Also to allow Weather Changer (a mod that allow changing weather just in clientside) to work with it.

From my testing, everything is working perfectly, but feel free to make any changes to this PR
here's an example working in wynncraft server

<img width="320" height="155" alt="2026-04-28_17 18 36" src="https://github.com/user-attachments/assets/8f269132-4234-443f-af77-46da342eae4e" />
